### PR TITLE
Feat/22

### DIFF
--- a/src/main/java/com/capstone/storyforest/sentencegame/appropriateness/dto/AppropriatenessResult.java
+++ b/src/main/java/com/capstone/storyforest/sentencegame/appropriateness/dto/AppropriatenessResult.java
@@ -1,0 +1,16 @@
+package com.capstone.storyforest.sentencegame.appropriateness.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+@AllArgsConstructor
+public class AppropriatenessResult {
+    private Boolean isAppropriate;
+    private List<String> mismatchedWords;
+}

--- a/src/main/java/com/capstone/storyforest/sentencegame/appropriateness/service/AppropriatenessService.java
+++ b/src/main/java/com/capstone/storyforest/sentencegame/appropriateness/service/AppropriatenessService.java
@@ -1,0 +1,9 @@
+package com.capstone.storyforest.sentencegame.appropriateness.service;
+
+import com.capstone.storyforest.sentencegame.appropriateness.dto.AppropriatenessResult;
+
+import java.util.List;
+
+public interface AppropriatenessService {
+    AppropriatenessResult evaluate(String sentence, List<String> requiredWords);
+}

--- a/src/main/java/com/capstone/storyforest/sentencegame/appropriateness/service/OpenAiAppropriatenessService.java
+++ b/src/main/java/com/capstone/storyforest/sentencegame/appropriateness/service/OpenAiAppropriatenessService.java
@@ -1,0 +1,77 @@
+package com.capstone.storyforest.sentencegame.appropriateness.service;
+
+import com.capstone.storyforest.sentencegame.appropriateness.dto.AppropriatenessResult;
+import com.capstone.storyforest.sentencegame.filtering.dto.OpenAiMessage;
+import com.capstone.storyforest.sentencegame.filtering.dto.OpenAiRequest;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.RequestEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OpenAiAppropriatenessService implements AppropriatenessService{
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${openai.api.url}")
+    private String apiUrl;
+
+    @Value("${openai.model}")
+    private String model;
+
+    @Value("${openai.api.key}")
+    private String apiKey;
+
+    @Override
+    public AppropriatenessResult evaluate(String sentence, List<String> requiredWords) {
+        try {
+            // 1) 프롬프트 제작
+            String prompt = String.format(
+                    "Evaluate whether the following sentence appropriately uses all required words.\n\n" +
+                            "Sentence: \"%s\"\n" +
+                            "Required words: %s\n\n" +
+                            "Respond *only* in pure JSON:\n" +
+                            "{\"isAppropriate\": true/false, \"mismatchedWords\": [/* list of words used incorrectly */]}",
+                    sentence, requiredWords);
+
+            // 2) OpenAiRequest 생성 & system 메시지 추가
+            OpenAiRequest req = new OpenAiRequest(model, prompt);
+            req.getMessages().add(0, new OpenAiMessage("system",
+                    "You are a semantic appropriateness evaluator. " +
+                            "Return only a JSON object with keys isAppropriate and mismatchedWords."));
+
+            // 3) HTTP 요청
+            RequestEntity<OpenAiRequest> request = RequestEntity
+                    .post(apiUrl)
+                    .header("Authorization", "Bearer " + apiKey)
+                    .body(req);
+
+            JsonNode root = restTemplate.exchange(request, JsonNode.class).getBody();
+
+            // 4) 응답 파싱
+            String content = root.path("choices").path(0).path("message").path("content")
+                    .asText().trim()
+                    .replaceAll("```", "").replaceAll("`", "");
+
+            log.debug("OpenAI 적절성 raw => {}", content);
+
+            // 5) DTO 변환
+            return objectMapper.readValue(content, AppropriatenessResult.class);
+
+        } catch (Exception e) {
+            log.error("OpenAI 적절성 평가 오류", e);
+            // 실패 시 ‘부적절’로 간주
+            return new AppropriatenessResult(false, List.of());
+        }
+    }
+
+}


### PR DESCRIPTION
## 📌 PR 제목
feat: 단어 사용 적절성 평가 로직(OpenAI 연동) 및 점수 계산 개선

---

## ✅ 작업 목적 (Why?)
- `SentenceService`에 “주어진 단어들의 사용이 의미상 적절한지” 평가하는 기능을 추가하여  
  단순 나열 형태의 문장에 대해 15점 부여를 방지하고, 보다 정교한 점수 분기 로직을 구현하고자 함.

---

## ✅ 주요 작업 내용 (What?)
- [x] `AppropriatenessResult` DTO 정의 (`isAppropriate`, `mismatchedWords`)
- [x] `AppropriatenessService` 인터페이스 추가
- [x] `OpenAiAppropriatenessService` 구현  
  - OpenAI 프롬프트 설계 및 system/user 메시지 구성  
  - JSON 파싱 및 예외 시 기본 `isAppropriate=false` 처리  
- [x] `SentenceService` 수정  
  - `AppropriatenessService` 주입 필드 추가  
  - 점수 계산 로직 변경  
    1. 7개 단어 포함 여부 검사 (실패 시 10점)  
    2. 포함 성공 시 `AppropriatenessService.evaluate()` 호출  
       - 적절성 통과 → 15점  
       - 미통과 → `CreativityService` 재호출 후 20점/10점 분기  
- [x] Postman으로 점수 케이스(10/15/20점) 테스트 완료

---

## 🐞 트러블슈팅 (문제 해결 경험)

| 문제 상황                                  | 원인                                                      | 해결 방법                                                                                      |
|-----------------------------------------|---------------------------------------------------------|---------------------------------------------------------------------------------------------|
| AI 평가 호출 시 JSON 외 추가 텍스트 포함          | OpenAI 모델이 백틱(```)이나 “json” 키워드를 붙여 응답함                  | 응답 문자열에서 백틱·마크다운 제거 후 `ObjectMapper`로 순수 JSON만 파싱하도록 처리                         |
| 적절성 평가 시 단어 나열형 문장도 `true`로 나오는 현상 | Prompt가 “모두 포함 여부”만 물어보고, 의미상 평가를 유도하지 못함             | Prompt 시스템 메시지에 “semantic appropriateness” 조건 추가, 잘못된 단어 리스트 반환하도록 수정               |
| 점수 로직 분기 순서 혼동                        | 기존 `creative` 분기와 섞여 이해하기 어려움                            | 분기를 명확히 세 단계(포함 여부 → 적절성 → 창의성)로 재정리                                     |

---

## 🧪 테스트 방법
- [x] **랜덤 단어 조회**  
  - `POST /api/sentence/random` → 7개 단어 정상 반환 확인  
- [x] **문장 제출 & 점수 케이스**  
  - 10점: 단어 누락 혹은 적절성·창의성 모두 실패  
  - 15점: 모든 단어 포함 + `isAppropriate=true`  
  - 20점: 모든 단어 포함 + `isAppropriate=false` + `isCreative=true`  
- [x] Postman 컬렉션 러너로 3개 케이스 자동화 테스트

---

## 📸 캡처 (Optional)
*Postman 요청/응답 스크린샷 첨부*

---

## 🔍 리뷰 요청사항
- OpenAI 프롬프트 문구 및 시스템 메시지 구성 적절성  
- `AppropriatenessService` 예외 처리(타임아웃/파싱 실패) 로직 보완 여부  
- 점수 계산 순서 및 비즈니스 로직 충실도 확인

---

## 📝 기타 참고 사항
- 향후 성능 고려해 호출 빈도 제한·캐싱 전략 추가 예정  
- `SimpleCreativityService` 대체 로직 논의 필요  
