### PR TITLE
Develop

### DIFF
--- a/src/main/java/com/capstone/storyforest/sentencegame/SentenceController.java
+++ b/src/main/java/com/capstone/storyforest/sentencegame/SentenceController.java
@@ -3,6 +3,7 @@ package com.capstone.storyforest.sentencegame;
 import com.capstone.storyforest.global.apiPaylod.ApiResponse;
 import com.capstone.storyforest.global.apiPaylod.code.status.SuccessStatus;
 import com.capstone.storyforest.sentencegame.dto.RandomWordRequestDTO;
+import com.capstone.storyforest.sentencegame.dto.SentenceFeedbackResponseDTO;
 import com.capstone.storyforest.sentencegame.dto.SentenceScoreResponseDTO;
 import com.capstone.storyforest.sentencegame.dto.SentenceSubmitRequestDTO;
 import com.capstone.storyforest.sentencegame.service.SentenceService;
@@ -40,7 +41,7 @@ public class SentenceController {
 
     /* B. 문장 제출 */
     @PostMapping("/score")
-    public ResponseEntity<ApiResponse<SentenceScoreResponseDTO>> score(
+    public ResponseEntity<ApiResponse<SentenceFeedbackResponseDTO>> score(
             @RequestBody @Valid SentenceSubmitRequestDTO sentenceSubmitRequestDTO,
             User user) throws JsonProcessingException {
 

--- a/src/main/java/com/capstone/storyforest/sentencegame/dto/SentenceFeedbackResponseDTO.java
+++ b/src/main/java/com/capstone/storyforest/sentencegame/dto/SentenceFeedbackResponseDTO.java
@@ -1,0 +1,10 @@
+package com.capstone.storyforest.sentencegame.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SentenceFeedbackResponseDTO {
+    private String feedback;
+}


### PR DESCRIPTION
## 📌 PR 제목  
feat: 문장 제출 로직 점수 계산 → 피드백 제공으로 변경

---

## ✅ 작업 목적 (Why?)  
- 기존에 점수(10/15/20)를 매기던 방식이 학습자에게 부담을 줄 수 있어,  
  간단한 피드백 메시지(1–2줄)로 교정 방향을 제시하도록 개선하고자 함

---

## ✅ 주요 작업 내용 (What?)  
- [x] `SentenceFeedbackResponseDTO` 추가 (피드백 문자열 전달용)  
- [x] `SentenceService.submitSentence(...)` 반환 타입을 `SentenceScoreResponseDTO` → `SentenceFeedbackResponseDTO`로 변경  
- [x] 기존 점수 계산 로직(usedAll → score 산정 및 user 총점 업데이트) 제거  
- [x] 누락 단어, 적절성·창의성 평가 결과에 따라 1–2줄 피드백 생성 로직 구현  
- [x] `SentenceController.score(...)` 메서드 반환 타입 및 서비스 호출부를 피드백 로직에 맞게 수정  
- [x] `sentenceText`, `terms` 변수 선언 위치 보완으로 컴파일 에러 해결  
- [x] DTO, 서비스, 컨트롤러 전반에 걸쳐 import·패키지 정리 및 주석 보강

---

## 🐞 트러블슈팅 (문제 해결 경험)

| 문제 상황                         | 원인                                               | 해결 방법                                                            |
|---------------------------------|--------------------------------------------------|---------------------------------------------------------------------|
| `sentenceText` 심볼 해결 불가     | 피드백 로직 도입 과정에서 변수 선언 누락               | 메서드 시작부에 `String sentenceText = dto.getSentenceText();` 추가 |
| `terms` 심볼 해결 불가            | 유사하게 `terms` 선언 위치가 빠져 있어 참조 불가        | `List<String> terms = words.stream()...` 선언 위치 보완              |
| 기존 점수 누적 로직 잔재로 인한 혼선 | 반환 타입 변경 후에도 `SentenceScoreResponseDTO` 참조 잔존 | 모든 서명 및 import를 `SentenceFeedbackResponseDTO`로 통일           |

---

## 🧪 테스트 방법  
- [x] Postman으로 `/api/sentence/score` 호출  
  - **케이스1**: 일부 단어 누락 문장 → “다음 단어들을 문장에 더 활용해 보세요: …” 응답 확인  
  - **케이스2**: 모든 단어 포함 & 적절한 문장 → “잘 작성했어요! 문장이 자연스럽고 어투가 적절합니다.” 응답 확인  
  - **케이스3**: 모든 단어 포함 & 부적절한 어투 → “문장 구성은 좋지만, 좀 더 다듬으면 더욱 창의적인 표현이 될 거예요!” 또는 “문장이 다소 어색해요. 간단히 다시 한 번 다듬어 보세요.” 응답 확인  
- [x] 컴파일 및 유닛 테스트(CI) 통과 확인  

---

## 📸 캡처 (Optional)  
_Postman 응답 예시_  
```json
{
  "reason": {
    "code": "COMMON200",
    "message": "성공입니다.",
    "isSuccess": true
  },
  "data": {
    "feedback": "다음 단어들을 문장에 더 활용해 보세요: apple, banana"
  }
}
